### PR TITLE
Feat/auto subtask function (useTasksWithPayload)

### DIFF
--- a/client/src/components/Issue.js
+++ b/client/src/components/Issue.js
@@ -1,66 +1,39 @@
-import React, { useContext } from 'react'
-import BoardSection from './BoardSection.js'
-import { useSections } from '../hooks/asana/useSections.js'
-import { useDateline } from '../reducers/useDateline.js'
+import React, {useEffect} from 'react'
+
 import {
 	WORKSPACE_GID as workspaceGid,
 	PROJECT_GID_LIST as projectIdList,
 } from '../configs/constent.js'
-import { ClientContext } from '../contexts/ClientContext.js'
-import { GidContext } from '../contexts/GidContext.js'
-import { DatelineContext } from '../contexts/DatelineContext.js'
-import { ProportionContext } from '../contexts/ProportionContext.js'
-import {
-	useProportion,
-} from '../reducers/useProportion.js'
+import {useTasksWithPayload} from '../hooks/asana/useTasksWithPayload'
+
+const issueProjectGid = projectIdList.ISSUE
+const issueSectionGid = '1201191083505009'
 
 function Issue() {
-	const projectGid = projectIdList.ISSUE
-	const issueSectionGid = '1201191083505009'
-	const { user } = useContext(ClientContext)
-	const { isFetching: isSectionsFetching, sections } = useSections({
-		projectGid,
-	})
-	const issueSection = sections.find(section =>
-		section.gid === issueSectionGid
-	)
-	const { dateline, proposeStartOn, proposeDueOn } = useDateline()
 	const {
-		accountingTasks,
-		appendAccountingTask,
-		deleteAccountingTask,
-	} = useProportion()
+		isFetching: isTasksFetching,
+		tasks,
+		fetchTasks,
+	} = useTasksWithPayload()
 
-	return (
-		<GidContext.Provider
-			value={{
-				workspaceGid,
-				projectGid,
-			}}>
-			<DatelineContext.Provider
-				value={{
-					dateline,
-					proposeStartOn,
-					proposeDueOn,
-				}}
-			>
-				<ProportionContext.Provider
-					value={{
-						accountingTasks,
-						appendAccountingTask,
-						deleteAccountingTask,
-					}}
-				>
-					{user.isFetching || isSectionsFetching ? (
-						<p>fetching...</p>
-					) : (
-						<BoardSection key={issueSection.key} section={issueSection}/>
-					)}
-				</ProportionContext.Provider>
-			</DatelineContext.Provider>
-		</GidContext.Provider>
-		
-	)
+	useEffect(() => {
+		async function fetchIssueTasks() {
+			await fetchTasks(workspaceGid, {
+				'projects.any': issueProjectGid,
+				'sections.any': issueSectionGid,
+			})
+		}
+
+		fetchIssueTasks()
+	}, [])
+
+	return <>
+		{isTasksFetching ? (
+			<p>fetching...</p>
+		) : (
+			<div>{JSON.stringify(tasks)}</div>
+		)}
+</>
 }
 
 export default Issue

--- a/client/src/components/Issue.js
+++ b/client/src/components/Issue.js
@@ -1,10 +1,14 @@
-import React, {useEffect} from 'react'
-
+import React, { useEffect } from 'react'
+import BoardTasks from './BoardTasks'
 import {
 	WORKSPACE_GID as workspaceGid,
 	PROJECT_GID_LIST as projectIdList,
 } from '../configs/constent.js'
-import {useTasksWithPayload} from '../hooks/asana/useTasksWithPayload'
+import { useTasksWithPayload } from '../hooks/asana/useTasksWithPayload'
+import { DatelineContext } from '../contexts/DatelineContext.js'
+import { ProportionContext } from '../contexts/ProportionContext.js'
+import { useDateline } from '../reducers/useDateline.js'
+import { useProportion } from '../reducers/useProportion.js'
 
 const issueProjectGid = projectIdList.ISSUE
 const issueSectionGid = '1201191083505009'
@@ -27,11 +31,30 @@ function Issue() {
 		fetchIssueTasks()
 	}, [])
 
+	const { dateline, proposeStartOn, proposeDueOn } = useDateline()
+	const { accountingTasks, appendAccountingTask, deleteAccountingTask } = useProportion()
+
 	return <>
 		{isTasksFetching ? (
 			<p>fetching...</p>
 		) : (
-			<div>{JSON.stringify(tasks)}</div>
+			<DatelineContext.Provider
+				value={{
+					dateline,
+					proposeStartOn,
+					proposeDueOn,
+				}}
+			>
+				<ProportionContext.Provider
+					value={{
+						accountingTasks,
+						appendAccountingTask,
+						deleteAccountingTask,
+					}}
+				>
+					<BoardTasks tasks={tasks} />
+				</ProportionContext.Provider>
+			</DatelineContext.Provider>
 		)}
 </>
 }

--- a/client/src/hooks/asana/useTasksWithPayload.js
+++ b/client/src/hooks/asana/useTasksWithPayload.js
@@ -1,0 +1,33 @@
+import {useCallback, useContext, useState} from 'react'
+import { ClientContext } from '../../contexts/ClientContext.js'
+
+export function useTasksWithPayload() {
+	const [tasks, setTasks] = useState([])
+	const [isFetching, setIsFetching] = useState(false)
+	const { client } = useContext(ClientContext)
+
+	const fetchTasks = useCallback(
+		async (workspace, payload) => {
+			try {
+				setIsFetching(true)
+				const { data: tasks = [] } = await client.tasks.searchTasksForWorkspace(
+					workspace,
+					payload
+				)
+
+				setTasks(tasks)
+			} catch (e) {
+				console.error(e)
+			} finally {
+				setIsFetching(false)
+			}
+		},
+		[client]
+	)
+
+	return {
+		isFetching,
+		tasks,
+		fetchTasks,
+	}
+}


### PR DESCRIPTION
新增
- `useTasksWithPayload` 由使用方傳入 payload 來 fetch tasks

修改
- 改用 `useTasksWithPayload` 取代 BoardSection 的 `useTasks`
- 跳過 `BoardSection` 直接使用 `BoardTasks` 顯示 tasks 結果
  ![ant_issue_tasks_demo](https://user-images.githubusercontent.com/79898185/228453831-d3db5d8b-a9e2-4d3f-943f-9f964ec645eb.gif)


其它
- `BoardTasks` 需要 `DatelineContext` & `ProportionContext` providers 配合，若不需要可以直接從 bae481f6a41a8417da2601e08b44002665b4426f 來自定 task 的顯示方式
- `user.isFetching` 是為了取到 `assigneeGid` 才繼續接下來的動作，若不需要指定 assignee 可以不用
